### PR TITLE
fix fonts

### DIFF
--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -44,6 +44,8 @@ const _fetchContent = async (pathToFetch: string, cacheFilePath: string): Promis
   const { window } = dom;
   const { document } = window;
 
+  applyGoogleFonts(document);
+
   // links
   const links = Array.from(document.querySelectorAll("link"));
   const linksArray = [];
@@ -61,8 +63,6 @@ const _fetchContent = async (pathToFetch: string, cacheFilePath: string): Promis
     }
     linksArray.push(mappedLink);
   }
-
-  applyGoogleFonts(document);
 
   // scripts
   const scripts = Array.from(document.querySelectorAll("script"));

--- a/app/api/helpers/content.helpers.ts
+++ b/app/api/helpers/content.helpers.ts
@@ -22,6 +22,6 @@ export const applyGoogleFonts = (document: Document) => {
   const link3 = document.createElement("link");
   link3.rel = "stylesheet";
   link3.href =
-    "https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap";
+    "https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&family=Roboto:wght@400;700&display=swap";
   document.head.appendChild(link3);
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,5 @@
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AppHeader } from "@/app/components/header";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 const RootLayout = async ({
   children,
@@ -20,7 +9,7 @@ const RootLayout = async ({
   return (
     <html lang="ru">
       <head></head>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body>
         <AppHeader />
         {children}
       </body>


### PR DESCRIPTION
- Remove default Geist fonts from the root layout.
- Update Google Fonts URL to use specific weights for Montserrat and Roboto.
- Reorder font injection in the content API to ensure injected links are processed correctly.